### PR TITLE
Add a basic optimization to prevent Termiku's CPU to skyrocket

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -168,11 +168,22 @@ impl <'a> Drawer<'a> {
         drawer
     }
     
-    pub fn update_dimensions(&mut self, display: &Display) {
-        self.dimensions = RectSize {
-            width: display.get_framebuffer_dimensions().0,
-            height: display.get_framebuffer_dimensions().1,
-        };
+    // update the dimensions of the drawer.
+    // returns true if those dimensions have changed
+    
+    pub fn update_dimensions(&mut self, display: &Display) -> bool {
+        let (width, height) = display.get_framebuffer_dimensions();
+        
+        let changed = self.dimensions.width != width || self.dimensions.height != height;
+        
+        if changed {
+            self.dimensions = RectSize {
+                width,
+                height,
+            };
+        }
+        
+        changed
     }
     
     fn rasterize(&mut self, characters: &str) -> Vec<FreeTypeGlyph> {

--- a/src/pty_buffer.rs
+++ b/src/pty_buffer.rs
@@ -56,7 +56,8 @@ impl CharacterLine {
 #[derive(Debug)]
 pub struct PtyBuffer {
     current_line: CharacterLine,
-    past_lines: VecDeque<CharacterLine>
+    past_lines: VecDeque<CharacterLine>,
+    updated: bool
 }
 
 impl PtyBuffer {
@@ -66,11 +67,14 @@ impl PtyBuffer {
         
         Self {
             current_line,
-            past_lines
+            past_lines,
+            updated: false
         }
     }
     
     pub fn add_input(&mut self, input: &str) {
+        self.updated = true;
+        
         let mut lines = input.split('\n').peekable();
         
         loop {
@@ -89,11 +93,17 @@ impl PtyBuffer {
         
     }
     
+    pub fn is_updated(&self) -> bool {
+        self.updated
+    }
+    
     // Get a range of lines (from the last one pushed, aka the newest, to the first one pushed, aka the oldest)
     // Won't panic if there's more
     // Will panic if end < start
-    pub fn get_range(&self, start: usize, end: usize) -> Vec<CharacterLine> {
+    pub fn get_range(&mut self, start: usize, end: usize) -> Vec<CharacterLine> {
         assert!(start <= end);
+        self.updated = false;
+        
         let number_of_line_requested = end - start + 1;
         let mut to_return: Vec<CharacterLine>;
         


### PR DESCRIPTION
Before this change, Termiku would use up to 50% CPU on my machine, which wasn't acceptable.

This commit tries to not render when nothing has changed from last frame, by checking both dimensions update and the active terminal buffer updates.

Termiku only uses 2% CPU now, which is still big but way more acceptable from before.